### PR TITLE
V0.23.1.0 for KSP 1.2.1

### DIFF
--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
@@ -1,4 +1,16 @@
-﻿V0.23.0.0
+﻿V0.23.1.0
+Fix Editor customer Filter for DeepFreeze parts.
+Fix problem with EC and Heat settings being disabled in new game difficulty settings. https://github.com/JPLRepo/DeepFreeze/issues/63
+Fix problem with CRY-0300 Doors opening/closing with JSI Advanced Transparent Pods showing an empty Internal until fully open, unfortunately
+it does mean you can no longer see the doors animate open/closed correctly. This is a limitation of the JSI Advanced Transparent Pods and camera setup for KSP.
+Performance improvement pass on the code.
+Fixed Difficulty Settings.
+Fixed incorrect use of Blizzy ToolBar on game startup even if user has set to use Stock Icon in difficulty settings.
+Implemented inter-mod GameEvents - better integration possible with other mods. 
+Fixed bug when Comatose Kerbal dies.
+Fixed Vessel Switching to unloaded vessel when Low EC or overheat warning occurs.
+Removed CRY-0300 door sound when JSI Advanced Transparent Pods mod shuts the door (not the user).
+V0.23.0.0
 Update for KSP 1.2
 Fix Coma Kerbals to register/unregister their traits at the correct time and handle Tourist kerbals.
 Added Setting in the menu that allows you to turn on/off the VAB/SPH Deepfreeze Parts Category Icon.

--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
@@ -1,4 +1,5 @@
 ﻿V0.23.1.0
+Compile for KSP 1.2.1
 Fix Editor customer Filter for DeepFreeze parts.
 Fix problem with EC and Heat settings being disabled in new game difficulty settings. https://github.com/JPLRepo/DeepFreeze/issues/63
 Fix problem with CRY-0300 Doors opening/closing with JSI Advanced Transparent Pods showing an empty Internal until fully open, unfortunately

--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
@@ -3,7 +3,7 @@
 "URL":"http://ksp-avc.cybutek.net/version.php?id=183",
 "DOWNLOAD":"http://spacedock.info/mod/142/DeepFreeze%20Continued...",
 "VERSION":{"MAJOR":0,"MINOR":23,"PATCH":1,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":0},
+"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":1},
 "KSP_VERSION_MIN":{"MAJOR":1,"MINOR":2,"PATCH":0},
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":0}
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":1}
 }

--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
@@ -2,7 +2,7 @@
 "NAME":"DeepFreeze Continued...",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=183",
 "DOWNLOAD":"http://spacedock.info/mod/142/DeepFreeze%20Continued...",
-"VERSION":{"MAJOR":0,"MINOR":23,"PATCH":0,"BUILD":0},
+"VERSION":{"MAJOR":0,"MINOR":23,"PATCH":1,"BUILD":0},
 "KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":0},
 "KSP_VERSION_MIN":{"MAJOR":1,"MINOR":2,"PATCH":0},
 "KSP_VERSION_MAX":{"MAJOR":1,"MINOR":2,"PATCH":0}

--- a/Source/DFEditorFilter.cs
+++ b/Source/DFEditorFilter.cs
@@ -16,12 +16,9 @@
  */
 
 using System.Collections.Generic;
-using System.IO;
 using KSP.UI.Screens;
 using RUI.Icons.Selectable;
 using UnityEngine;
-using System.Reflection;
-using System.Linq;
 
 namespace DF
 {
@@ -31,7 +28,7 @@ namespace DF
         // This class ass a Filter Icon to the Editor to show DeepFreeze Parts
         // which currently consist of any partprefab that has component DeepFreezer (All the freezer parts)
         // and the GlykerolTankRadial.
-        private static List<AvailablePart> avPartItems;
+        private static List<AvailablePart> avPartItems = new List<AvailablePart>();
         public static DFEditorFilter Instance;
         internal string category = "Filter by Function";
         internal string subCategoryTitle = "DeepFreeze Items";
@@ -54,39 +51,24 @@ namespace DF
             DontDestroyOnLoad(this);
         }
 
-        public void Setup(bool FilterOn)
+        public void Setup()
         {
             Debug.Log("DFEditorFilter Start");
-            avPartItems = new List<AvailablePart>();
-            //icon_DeepFreeze_Editor = new Texture2D(32, 32, TextureFormat.ARGB32, false);
-
+            RemoveSubFilter();
+            AddPartUtilitiesCat();
             GameEvents.onGUIEditorToolbarReady.Remove(SubCategories);
+            
 
-            DFMMCallBack();
-
-            if (!FilterOn)
+            if (!HighLogic.CurrentGame.Parameters.CustomParams<DeepFreeze_SettingsParms_Sec3>().EditorFilter)
             {
                 Debug.Log("EditorFilter Option is Off");
-                PartCategorizer.Category Filter =
-                    PartCategorizer.Instance.filters.Find(f => f.button.categoryName == category);
-                if (Filter != null)
-                {
-                    PartCategorizer.Category subFilter =
-                        Filter.subcategories.Find(f => f.button.categoryName == subCategoryTitle);
-                    if (subFilter != null)
-                    {
-                        //MethodInfo subFilterDeleteMethod =
-                        //    typeof(PartCategorizer.Category).GetMethod("DeleteSubcategory",
-                        //        BindingFlags.Instance | BindingFlags.NonPublic);
-                        //subFilterDeleteMethod.Invoke(subFilter, null);
-                        subFilter.DeleteSubcategory();
-                    }
-                }
-                GameEvents.onGUIEditorToolbarReady.Remove(SubCategories);
-                AddPartUtilitiesCat();
                 return;
             }
 
+
+            Debug.Log("EditorFilter Option is On");
+            DFMMCallBack();
+            RemovePartUtilitiesCat();
             GameEvents.onGUIEditorToolbarReady.Add(SubCategories);
             /*
             //Attempt to add Module Manager callback  - find the base type
@@ -108,9 +90,6 @@ namespace DF
                 
             }*/
             //DFMMCallBack();
-            //load the icons
-            //icon_DeepFreeze_Editor.LoadImage(File.ReadAllBytes("GameData/REPOSoftTech/DeepFreeze/Icons/DeepFreezeEditor.png"));
-            RemovePartUtilitiesCat();
             Debug.Log("DFEditorFilter Awake Complete");
         }
 
@@ -131,11 +110,26 @@ namespace DF
             return true;
         }
 
+        private void RemoveSubFilter()
+        {
+            if (PartCategorizer.Instance != null)
+            {
+                PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == category);
+                if (Filter != null)
+                {
+                    PartCategorizer.Category subFilter = Filter.subcategories.Find(f => f.button.categoryName == subCategoryTitle);
+                    if (subFilter != null)
+                    {
+                        subFilter.DeleteSubcategory();
+                    }
+                }
+            }
+        }
+
         private void RemovePartUtilitiesCat()
         {
             foreach (AvailablePart avPart in avPartItems)
             {
-                //PartCategorizer.Instance.subcategoryFunctionUtility.RemovePart(avPart);
                 avPart.category = PartCategories.none;
             }
         }
@@ -144,7 +138,6 @@ namespace DF
         {
             foreach (AvailablePart avPart in avPartItems)
             {
-                //PartCategorizer.Instance.subcategoryFunctionUtility.AddPart(avPart);
                 avPart.category = PartCategories.Utility;
             }
         }
@@ -160,12 +153,10 @@ namespace DF
 
         private void SubCategories()
         {
+            RemoveSubFilter();
             Icon filterDeepFreeze = new Icon("DeepFreezeEditor", Textures.DeepFreeze_Editor, Textures.DeepFreeze_Editor, true);
             PartCategorizer.Category Filter = PartCategorizer.Instance.filters.Find(f => f.button.categoryName == category);
             PartCategorizer.AddCustomSubcategoryFilter(Filter, subCategoryTitle, filterDeepFreeze, p => EditorItemsFilter(p));
-            //RUIToggleButtonTyped button = Filter.button.activeButton;
-            //button.SetFalse(button, RUIToggleButtonTyped.ClickType.FORCED);
-            //button.SetTrue(button, RUIToggleButtonTyped.ClickType.FORCED);
         }
     }
 }

--- a/Source/DFSettings.cs
+++ b/Source/DFSettings.cs
@@ -259,7 +259,7 @@ namespace DF
                     {
                         EditorFilter = DF_SettingsParms_Sec3.EditorFilter;
                         if (DFEditorFilter.Instance != null)
-                            DFEditorFilter.Instance.Setup(EditorFilter);
+                            DFEditorFilter.Instance.Setup();
                     }
                 }
                 else

--- a/Source/DeepFreeze.cs
+++ b/Source/DeepFreeze.cs
@@ -128,7 +128,7 @@ namespace DF
             }
             if (HighLogic.LoadedScene == GameScenes.SPACECENTER)
             {
-                DFEditorFilter.Instance.Setup(DFsettings.EditorFilter);
+                DFEditorFilter.Instance.Setup();
             }
             Utilities.debuggingOn = DFsettings.debugging;
             APIReady = true;
@@ -376,6 +376,7 @@ namespace DF
                 Utilities.Log("DeepFreezeEvents " + kerbal.name + " killed");
                 kerbal.type = ProtoCrewMember.KerbalType.Crew;
                 kerbal.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
+                RSTKSPGameEvents.RSTEvents.onFrozenKerbalDied.Fire(kerbal);
                 if (HighLogic.CurrentGame.Parameters.Difficulty.MissingCrewsRespawn)
                 {
                     kerbal.StartRespawnPeriod();
@@ -388,17 +389,18 @@ namespace DF
                 ProtoCrewMember crew = HighLogic.CurrentGame.CrewRoster.Tourist.FirstOrDefault(a => a.name == FrozenCrew);
                 if (crew != null)
                 {
-                    Utilities.Log("DeepFreezeEvents " + kerbal.name + " killed");
-                    kerbal.type = ProtoCrewMember.KerbalType.Crew;
-                    kerbal.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
+                    Utilities.Log("DeepFreezeEvents " + crew.name + " killed");
+                    crew.type = ProtoCrewMember.KerbalType.Crew;
+                    crew.rosterStatus = ProtoCrewMember.RosterStatus.Dead;
+                    RSTKSPGameEvents.RSTEvents.onFrozenKerbalDied.Fire(crew);
                     if (HighLogic.CurrentGame.Parameters.Difficulty.MissingCrewsRespawn)
                     {
-                        kerbal.StartRespawnPeriod();
-                        Utilities.Log("DeepFreezeEvents " + kerbal.name + " respawn started.");
+                        crew.StartRespawnPeriod();
+                        Utilities.Log("DeepFreezeEvents " + crew.name + " respawn started.");
                     }
                 }
                 else
-                    Utilities.Log("DeepFreezeEvents " + kerbal.name + " couldn't find them to kill them.");
+                    Utilities.Log("DeepFreezeEvents " + crew.name + " couldn't find them to kill them.");
             }
         }
 
@@ -409,6 +411,7 @@ namespace DF
                 if (start)
                 {
                     crew.UnregisterExperienceTraits(part);
+                    RSTKSPGameEvents.RSTEvents.onKerbalSetComatose.Fire(part, crew);
                 }
 
                 crew.type = type;
@@ -424,6 +427,7 @@ namespace DF
                         KerbalRoster.SetExperienceTrait(crew, "Tourist");
                     }
                     crew.RegisterExperienceTraits(part);
+                    RSTKSPGameEvents.RSTEvents.onKerbalUnSetComatose.Fire(part, crew);
                     ScreenMessages.PostScreenMessage(
                             crew.name + " has recovered from emergency thaw and resumed normal duties.", 5.0f,
                             ScreenMessageStyle.UPPER_CENTER);

--- a/Source/DeepFreeze.csproj
+++ b/Source/DeepFreeze.csproj
@@ -40,6 +40,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\KSPDLLs - 1.2\Assembly-CSharp.dll</HintPath>
     </Reference>
+    <Reference Include="RSTKSPGameEvents">
+      <HintPath>..\..\REPOSoftTechKSPUtils\RSTKSPGameEvents\bin\Debug\RSTKSPGameEvents.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Source/KerbalPortraits.cs
+++ b/Source/KerbalPortraits.cs
@@ -1,7 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
+﻿/**
+ * DeepFreeze Continued...
+ * (C) Copyright 2015, Jamie Leighton
+ *
+ * Kerbal Space Program is Copyright (C) 2013 Squad. See http://kerbalspaceprogram.com/. This
+ * project is in no way associated with nor endorsed by Squad.
+ *
+ *  This file is part of JPLRepo's DeepFreeze (continued...) - a Fork of DeepFreeze. Original Author of DeepFreeze is 'scottpaladin' on the KSP Forums.
+ *  This File was not part of the original Deepfreeze but was written by Jamie Leighton.
+ *  (C) Copyright 2015, Jamie Leighton
+ *
+ * Continues to be licensed under the Attribution-NonCommercial-ShareAlike 3.0 (CC BY-NC-SA 4.0)
+ * creative commons license. See <https://creativecommons.org/licenses/by-nc-sa/4.0/>
+ * for full details.
+ *
+ */
 using KSP.UI.Screens.Flight;
 using UnityEngine;
 
@@ -11,18 +23,25 @@ namespace DeepFreeze
     [KSPAddon(KSPAddon.Startup.Flight, false)]
     class DFPortraits : MonoBehaviour
     {
-
-        internal static BindingFlags eFlags = BindingFlags.Instance | BindingFlags.NonPublic;
-        
         internal static bool HasPortrait(Kerbal crew, bool checkName = false)
         {
             if (!checkName)
             {
-                return KerbalPortraitGallery.Instance.Portraits.Any(p => p.crewMember == crew);
+                for (int i = 0; i < KerbalPortraitGallery.Instance.Portraits.Count; ++i)
+                {
+                    if (KerbalPortraitGallery.Instance.Portraits[i].crewMember == crew)
+                        return true;
+                }
+                return false;
             }
             else
             {
-                return KerbalPortraitGallery.Instance.Portraits.Any(p => p.crewMemberName == crew.crewMemberName);
+                for (int i = 0; i < KerbalPortraitGallery.Instance.Portraits.Count; ++i)
+                {
+                    if (KerbalPortraitGallery.Instance.Portraits[i].crewMemberName == crew.crewMemberName)
+                        return true;
+                }
+                return false;
             }
         }
 
@@ -30,11 +49,21 @@ namespace DeepFreeze
         {
             if (!checkName)
             {
-                return KerbalPortraitGallery.Instance.ActiveCrew.Any(p => p == crew);
+                for (int i = 0; i < KerbalPortraitGallery.Instance.ActiveCrew.Count; ++i)
+                {
+                    if (KerbalPortraitGallery.Instance.ActiveCrew[i] == crew)
+                        return true;
+                }
+                return false;
             }
             else
             {
-                return KerbalPortraitGallery.Instance.ActiveCrew.Any(p => p.crewMemberName == crew.crewMemberName);
+                for (int i = 0; i < KerbalPortraitGallery.Instance.ActiveCrew.Count; ++i)
+                {
+                    if (KerbalPortraitGallery.Instance.ActiveCrew[i].crewMemberName == crew.crewMemberName)
+                        return true;
+                }
+                return false;
             }
         }
 

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.23.0.0")]
-[assembly: AssemblyFileVersion("0.23.0.0")]
+[assembly: AssemblyVersion("0.23.1.0")]
+[assembly: AssemblyFileVersion("0.23.1.0")]
 [assembly: KSPAssembly("DeepFreeze", 0, 23)] 

--- a/Source/SettingsParms.cs
+++ b/Source/SettingsParms.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Text;
 using UnityEngine;
 
-namespace DeepFreeze
+namespace DF
 {
     public class DeepFreeze_SettingsParms : GameParameters.CustomParameterNode
 
@@ -44,34 +44,32 @@ namespace DeepFreeze
             switch (preset)
             {
                 case GameParameters.Preset.Easy:
-                    ECreqdForFreezer = false;
-                    AutoRecoverFznKerbals = true;
-                    KSCcostToThawKerbal = 5000f;
-                    ECReqdToFreezeThaw = 1000;
-                    GlykerolReqdToFreeze = 5;
+                    this.ECreqdForFreezer = false;
+                    this.AutoRecoverFznKerbals = true;
+                    this.KSCcostToThawKerbal = 5000f;
+                    this.ECReqdToFreezeThaw = 1000;
+                    this.GlykerolReqdToFreeze = 5;
                     break;
                 case GameParameters.Preset.Normal:
-                    ECreqdForFreezer = false;
-                    AutoRecoverFznKerbals = true;
-                    KSCcostToThawKerbal = 10000f;
-                    ECReqdToFreezeThaw = 2000;
-                    GlykerolReqdToFreeze = 5;
+                    this.ECreqdForFreezer = false;
+                    this.AutoRecoverFznKerbals = true;
+                    this.KSCcostToThawKerbal = 10000f;
+                    this.ECReqdToFreezeThaw = 2000;
+                    this.GlykerolReqdToFreeze = 5;
                     break;
                 case GameParameters.Preset.Moderate:
-                    ECreqdForFreezer = true;
-                    AutoRecoverFznKerbals = false;
-                    KSCcostToThawKerbal = 20000f;
-                    ECReqdToFreezeThaw = 3000;
-                    GlykerolReqdToFreeze = 10;
+                    this.ECreqdForFreezer = true;
+                    this.AutoRecoverFznKerbals = false;
+                    this.KSCcostToThawKerbal = 20000f;
+                    this.ECReqdToFreezeThaw = 3000;
+                    this.GlykerolReqdToFreeze = 10;
                     break;
                 case GameParameters.Preset.Hard:
-                    ECreqdForFreezer = true;
-                    AutoRecoverFznKerbals = false;
-                    KSCcostToThawKerbal = 30000f;
-                    ECReqdToFreezeThaw = 4000;
-                    GlykerolReqdToFreeze = 15;
-                    break;
-                case GameParameters.Preset.Custom:
+                    this.ECreqdForFreezer = true;
+                    this.AutoRecoverFznKerbals = false;
+                    this.KSCcostToThawKerbal = 30000f;
+                    this.ECReqdToFreezeThaw = 4000;
+                    this.GlykerolReqdToFreeze = 15;
                     break;
             }
         }
@@ -82,9 +80,7 @@ namespace DeepFreeze
             {
                 if (HighLogic.LoadedSceneIsFlight)
                 {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
-                        return false;
+                    return false;
                 }
             }
 
@@ -97,31 +93,21 @@ namespace DeepFreeze
             {
                 if (HighLogic.LoadedSceneIsFlight)
                 {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
-                        return false;
+                    return false;
                 }
             }
             if (member.Name == "fatalOption")
             {
-                if (ECreqdForFreezer)
-                    return true;
-                else
-                    return false;
+                return parameters.CustomParams<DeepFreeze_SettingsParms>().ECreqdForFreezer;
             }
             if (member.Name == "comatoseTime")
             {
-                if (ECreqdForFreezer && !fatalOption)
-                    return true;
-                else
-                    return false;
+                return (parameters.CustomParams<DeepFreeze_SettingsParms>().ECreqdForFreezer &&
+                        !parameters.CustomParams<DeepFreeze_SettingsParms>().fatalOption);
             }
             if (member.Name == "KSCcostToThawKerbal")
             {
-                if (AutoRecoverFznKerbals)
-                    return true;
-                else
-                    return false;
+                return parameters.CustomParams<DeepFreeze_SettingsParms>().AutoRecoverFznKerbals;
             }
             
             return true;
@@ -164,35 +150,18 @@ namespace DeepFreeze
             switch (preset)
             {
                 case GameParameters.Preset.Easy:
-                    RegTempReqd = false;
+                    this.RegTempReqd = false;
                     break;
                 case GameParameters.Preset.Normal:
-                    RegTempReqd = false;
+                    this.RegTempReqd = false;
                     break;
                 case GameParameters.Preset.Moderate:
-                    RegTempReqd = true;
+                    this.RegTempReqd = true;
                     break;
                 case GameParameters.Preset.Hard:
-                    RegTempReqd = true;
-                    break;
-                case GameParameters.Preset.Custom:
+                    this.RegTempReqd = true;
                     break;
             }
-        }
-
-        public override bool Enabled(MemberInfo member, GameParameters parameters)
-        {
-            if (HighLogic.fetch != null)
-            {
-                if (HighLogic.LoadedSceneIsFlight)
-                {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
-                        return false;
-                }
-            }
-            
-            return true;
         }
 
         public override bool Interactible(MemberInfo member, GameParameters parameters)
@@ -201,18 +170,14 @@ namespace DeepFreeze
             {
                 if (HighLogic.LoadedSceneIsFlight)
                 {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
+                    if (member.Name != "TempinKelvin")
                         return false;
                 }
             }
             
             if (member.Name == "RegTempFreeze" || member.Name == "RegTempMonitor" || member.Name == "heatamtMonitoringFrznKerbals" || member.Name == "heatamtThawFreezeKerbal")
             {
-                if (RegTempReqd)
-                    return true;
-                else
-                    return false;
+                return parameters.CustomParams<DeepFreeze_SettingsParms_Sec2>().RegTempReqd;
             }
             
             return true;
@@ -224,7 +189,7 @@ namespace DeepFreeze
     {
         public override string Title { get { return "DeepFreeze Misc."; } }
         public override GameParameters.GameMode GameMode { get { return GameParameters.GameMode.ANY; } }
-        public override bool HasPresets { get { return true; } }
+        public override bool HasPresets { get { return false; } }
         public override string Section { get { return "DeepFreeze"; } }
         public override int SectionOrder { get { return 3; } }
         
@@ -242,62 +207,14 @@ namespace DeepFreeze
 
         [GameParameters.CustomParameterUI("Extra Debug Logging", toolTip = "Turn this On to capture lots of extra information\ninto the KSP log for reporting a problem.")]
         public bool DebugLogging = false;
-
-        public override void SetDifficultyPreset(GameParameters.Preset preset)
-        {
-            Debug.Log("Setting difficulty preset");
-            switch (preset)
-            {
-                case GameParameters.Preset.Easy:
-                    
-                    break;
-                case GameParameters.Preset.Normal:
-                    
-                    break;
-                case GameParameters.Preset.Moderate:
-                    
-                    break;
-                case GameParameters.Preset.Hard:
-                    
-                    break;
-                case GameParameters.Preset.Custom:
-                    break;
-            }
-        }
-
-        public override bool Enabled(MemberInfo member, GameParameters parameters)
-        {
-            if (HighLogic.fetch != null)
-            {
-                if (HighLogic.LoadedSceneIsFlight)
-                {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
-                        return false;
-                }
-            }
-
-            return true;
-        }
-
+        
         public override bool Interactible(MemberInfo member, GameParameters parameters)
         {
-            if (HighLogic.fetch != null)
-            {
-                if (HighLogic.LoadedSceneIsFlight)
-                {
-                    if (member.Name != "TempinKelvin" && member.Name != "StripLightsActive" && member.Name != "ToolTips" &&
-                        member.Name != "UseAppLToolbar" && member.Name != "DebugLogging")
-                        return false;
-                }
-            }
-            
             if (member.Name == "UseAppLToolbar")
             {
                 if (RSTUtils.ToolbarManager.ToolbarAvailable)
                     return true;
-                else
-                    return false;
+                return false;
             }
 
             return true;


### PR DESCRIPTION
V0.23.1.0
Compile for KSP 1.2.1
Fix Editor customer Filter for DeepFreeze parts.
Fix problem with EC and Heat settings being disabled in new game difficulty settings. https://github.com/JPLRepo/DeepFreeze/issues/63
Fix problem with CRY-0300 Doors opening/closing with JSI Advanced Transparent Pods showing an empty Internal until fully open, unfortunately
it does mean you can no longer see the doors animate open/closed correctly. This is a limitation of the JSI Advanced Transparent Pods and camera setup for KSP.
Performance improvement pass on the code.
Fixed Difficulty Settings.
Fixed incorrect use of Blizzy ToolBar on game startup even if user has set to use Stock Icon in difficulty settings.
Implemented inter-mod GameEvents - better integration possible with other mods. 
Fixed bug when Comatose Kerbal dies.
Fixed Vessel Switching to unloaded vessel when Low EC or overheat warning occurs.
Removed CRY-0300 door sound when JSI Advanced Transparent Pods mod shuts the door (not the user).