### PR TITLE
Fix launched vessel not getting tracked when it has more freezer parts than another existing vessel

### DIFF
--- a/Source/DFIntMemory.cs
+++ b/Source/DFIntMemory.cs
@@ -927,7 +927,7 @@ namespace DF
                 if (frzrpart.Value.vesselID == vessel.id)
                     DpFrzrVsl.Add(frzrpart);
             }
-            for (int i = 0; i < DpFrzrActVsl.Count; i++)
+            for (int i = 0; i < DpFrzrVsl.Count; i++)
             {
                 //calculate the predicated time EC will run out
                 double timeperiod = Planetarium.GetUniversalTime() - DpFrzrVsl[i].Value.timeLastElectricity;


### PR DESCRIPTION
Before that: if you have a previous vessel with N freezer parts, any new vessel you launch having more than N parts will not be tracked (freezing its kerbals will lose them).

(Because UpdatePredictedVesselEC is called for previous vessels, but it iterated with the wrong counter (looping on N parts with max index M-1). This leads to an exception, preventing the huge CheckVslUpdate from completing and adding the new vessel).