### PR TITLE
Updates for KSP 1.12.x

### DIFF
--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/Changelog.txt
@@ -1,4 +1,10 @@
-﻿V0.30.0.0
+﻿V0.31.0.0
+Re-Compile for KSP 1.12.x
+Added difficulty settings to turn off internal beep sounds and all sounds.
+Fix background resources - Kopernicus solar panels integration.
+Fix Portraits showing from kerbals in loaded vessels that aren't the active vessel.
+Fix timing issue with the Cryopod door animation and freeze glass animation playing at the same time. They now play one after another as they used to/should.
+V0.30.0.0
 Re-Compile for KSP 1.11.x
 Add EVA construction capabilities to the CRY-300R (Can move it only, can't put in inventories) and the RS-X20R Glykerol Container (can be put in inventories as well).
 V0.29.0.0

--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/DFLocalization.cfg
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/DFLocalization.cfg
@@ -212,7 +212,11 @@ Localization
 		#autoLOC_DF_00200 = Thaw <<1>>
 		
 		#autoLOC_DF_00201 = Unloaded Vessel Processing
-		#autoLOC_DF_00202 = If enabled DeepFreeze will process resources on unloaded vessels. If disabled, it won't and play the catchup and estimation game.		
+		#autoLOC_DF_00202 = If enabled DeepFreeze will process resources on unloaded vessels. If disabled, it won't and play the catchup and estimation game.
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.				
 	}
 }
 
@@ -431,224 +435,10 @@ Localization
 		
 		#autoLOC_DF_00201 = Procesamiento de naves sin Carga
 		#autoLOC_DF_00202 = Si se habilita, CongelaciónProfunda procesará los recursos en las naves sin carga. Si está deshabilitado, no lo hará y jugará el juego de recuperación y estimación.
-	}
-}
-
-Localization
-{
-	es-mx
-	{
-		#autoLOC_DF_00001 = <<1>> has recovered from emergency thaw and resumed normal duties.
-		#autoLOC_DF_00002 = <<1>> has been emergency thawed and cannot perform duties for <<2>> minutes.
-		#autoLOC_DF_00003 = DeepFreeze
-		#autoLOC_DF_00004 = DeepFreeze Vessel Switch
-		#autoLOC_DF_00005 = DeepFreeze Vessel Switch Failed
-		#autoLOC_DF_00006 = DeepFreeze Kerbals
-		#autoLOC_DF_00007 = DeepFreeze Alarms
-		#autoLOC_DF_00008 = Close Window
-		#autoLOC_DF_00009 = Vessel
-		#autoLOC_DF_00010 = Vessel Name
-		#autoLOC_DF_00011 = Part
-		#autoLOC_DF_00012 = Part Name
-		#autoLOC_DF_00013 = Tmp
-		#autoLOC_DF_00014 = Part Temperature Status
-		#autoLOC_DF_00015 = EC
-		#autoLOC_DF_00016 = Electric Charge Status
-		#autoLOC_DF_00017 = R.T
-		#autoLOC_DF_00018 = Remote Tech Status
-		#autoLOC_DF_00019 = Alarms
-		#autoLOC_DF_00020 = Press the button for Kerbal Alarm Clock Alarms assigned to this part
-		#autoLOC_DF_00021 = LastUpd
-		#autoLOC_DF_00022 = The Time the part was last updated
-		#autoLOC_DF_00023 = TimeRem
-		#autoLOC_DF_00024 = Approx. time remaining before Electric Charge will run out
-		#autoLOC_DF_00025 = Vessel <<1>> is Over-Heating.
-		#autoLOC_DF_00026 = OFF
-		#autoLOC_DF_00027 = S/BY
-		#autoLOC_DF_00028 = OUT
-		#autoLOC_DF_00029 = Vesssel <<1>> is out of ElectricCharge.\n Situation Critical.
-		#autoLOC_DF_00030 = ALRT
-		#autoLOC_DF_00031 = Vessel <<1>> is almost out of ElectricCharge.
-		#autoLOC_DF_00032 = LOW
-		#autoLOC_DF_00033 = OK
-		#autoLOC_DF_00034 = NC
-		#autoLOC_DF_00035 = Alarm
-		#autoLOC_DF_00036 = Go to Alarms
-		#autoLOC_DF_00037 = There are currently no Frozen Kerbals
-		#autoLOC_DF_00038 = Kerbal Name
-		#autoLOC_DF_00039 = Profession
-		#autoLOC_DF_00040 = Thaw
-		#autoLOC_DF_00041 = Thaw this kerbal
-		#autoLOC_DF_00042 = Cannot thaw <<1>> from KSC. Vessel still exists <<2>> at <<3>>
-		#autoLOC_DF_00043 = Freeze
-		#autoLOC_DF_00044 = Freeze this kerbal
-		#autoLOC_DF_00045 = KAC Alarms
-		#autoLOC_DF_00046 = Resize Window
-		#autoLOC_DF_00047 = <<1>>K
-		#autoLOC_DF_00048 = <<2>>C
-		#autoLOC_DF_00049 = <<1>> was stored frozen at KSC
-		#autoLOC_DF_00050 = Insufficient funds to thaw <<1>> at this time
-		#autoLOC_DF_00051 = <<1>> was found and thawed out
-		#autoLOC_DF_00052 = <<1>> was found and thawed out <<2>> funds deducted from account
-		#autoLOC_DF_00053 = Cannot thaw <<1>> vessel still exists <<2>> at <<3>>
-		
-		#autoLOC_DF_00054 = Freezer Capacity
-		#autoLOC_DF_00055 = Total Frozen Kerbals
-		#autoLOC_DF_00056 = Freezer Space
-		#autoLOC_DF_00057 = Part is Full?
-		#autoLOC_DF_00058 = R/T Connection
-		#autoLOC_DF_00059 = Freezer Temp
-		#autoLOC_DF_00060 = Cabin Temperature
-		#autoLOC_DF_00061 = K
-		#autoLOC_DF_00062 = DeepFreeze Menu
-		#autoLOC_DF_00063 = EC p/Kerbal to run
-		#autoLOC_DF_00064 = \u0020p/min
-		#autoLOC_DF_00065 = Current EC Usage
-		#autoLOC_DF_00066 = \u0020p/sec
-		#autoLOC_DF_00067 = Glykerol Reqd. to Freeze
-		#autoLOC_DF_00068 = EC p/Kerbal to Frze/Thaw
-		#autoLOC_DF_00069 = \nCryopods: <<1>>
-		#autoLOC_DF_00070 = C
-		#autoLOC_DF_00071 = Pod:<<1>>
-		#autoLOC_DF_00072 = Insufficient electric charge to monitor frozen kerbals.
-		#autoLOC_DF_00073 = \u0020Freezer Out of EC : Systems critical in <<1>> secs
-		#autoLOC_DF_00074 = <<1>> died due to lack of Electrical Charge to run cryogenics
-		#autoLOC_DF_00075 = Check Temperatures, Freezer getting hot
-		#autoLOC_DF_00076 = Warning!! Check Temperatures NOW, Freezer getting very hot
-		#autoLOC_DF_00077 = Temperature getting too hot for kerbals to remain frozen.
-		#autoLOC_DF_00078 = Freezer Over Temp : Systems critical in <<1>> secs
-		#autoLOC_DF_00079 = <<1>> died due to overheating, cannot keep frozen
-		#autoLOC_DF_00080 = Over Temperature - Emergency Thaw in Progress.
-		#autoLOC_DF_00081 = Insufficient electric charge to freeze kerbal
-		#autoLOC_DF_00082 = \u0020Cryopod - Charging: <<1>>
-		#autoLOC_DF_00083 = Insufficient Glykerol to freeze kerbal
-		#autoLOC_DF_00084 = Cannot Freeze while Temperature greater than <<1>> 
-		#autoLOC_DF_00085 = Cannot Freeze while Crew Xfer in progress
-		#autoLOC_DF_00086 = Cannot run Freeze process on more than one Kerbal at a time
-		#autoLOC_DF_00087 = RemoteTech Detected. Press Freeze Again if you want to Freeze your Last Active Kerbal
-		#autoLOC_DF_00088 = An Active connection or Active Kerbal is Required On-Board to Initiate Thaw Process
-		#autoLOC_DF_00089 = Cannot freeze kerbal. Freezer is full
-		#autoLOC_DF_00090 = Cannot freeze kerbal at this time
-		#autoLOC_DF_00091 = Starting Freeze process
-		#autoLOC_DF_00092 = Freezing Aborted
-		#autoLOC_DF_00093 = <<1>> frozen
-		#autoLOC_DF_00094 = Insufficient electric charge to thaw kerbal
-		#autoLOC_DF_00095 = \u0020Cryopod - Charging:<<1>> 
-		#autoLOC_DF_00096 = Cannot Thaw <<1>> Part is full
-		#autoLOC_DF_00097 = Cannot Thaw while Crew Xfer in progress
-		#autoLOC_DF_00098 = Cannot run Thaw process on more than one Kerbal at a time
-		#autoLOC_DF_00099 = Cannot thaw kerbal at this time
-		#autoLOC_DF_00100 = Code Error: Cannot thaw kerbal at this time, Check Log
-		#autoLOC_DF_00101 = Thawing Aborted
-		#autoLOC_DF_00102 = <<1>> thawed out
-		#autoLOC_DF_00103 = <<1>> was thawed out due to lack of Electrical Charge to run cryogenics
-		#autoLOC_DF_00104 = DeepFreezer mechanical failure
-		#autoLOC_DF_00105 = Vessel about to change, Aborting Thaw process
-		#autoLOC_DF_00106 = Vessel about to change, Aborting Freeze process
-		
-		#autoLOC_DF_00107 = DeepFreeze Items
-		#autoLOC_DF_00108 = There is less than 5 units of Glykerol on-board for your DeepFreeze Freezers
-		#autoLOC_DF_00109 = A DeepFreeze Alarm event has occurred. Please Switch to <<1>> to execute.
-		#autoLOC_DF_00110 = DeepFreeze Alarm processing completed.
-		
-		#autoLOC_DF_00111 = Name
-		#autoLOC_DF_00112 = Alarm Name
-		#autoLOC_DF_00113 = Alarm Type
-		#autoLOC_DF_00114 = KAC Alarm Type
-		#autoLOC_DF_00115 = Time Remain.
-		#autoLOC_DF_00116 = Time remaining before Alarm is triggered
-		#autoLOC_DF_00117 = There are currently no KAC alarms associated to a DeepFreeze vessel
-		#autoLOC_DF_00118 = Delete
-		#autoLOC_DF_00119 = Delete this KAC alarm completely
-		#autoLOC_DF_00120 = Modify
-		#autoLOC_DF_00121 = Modify this Alarm
-		#autoLOC_DF_00122 = Save
-		#autoLOC_DF_00123 = Save Alarm Changes
-		#autoLOC_DF_00124 = Cannot Save Alarm. No R/Tech Connection to vessel.
-		#autoLOC_DF_00125 = DeepFreeze Alarm changes Saved.
-		#autoLOC_DF_00126 = DeepFreeze Cannot Save alarm changes, Time is up.
-		#autoLOC_DF_00127 = Cancel
-		#autoLOC_DF_00128 = Cancel any changes
-		#autoLOC_DF_00129 = Name
-		#autoLOC_DF_00130 = The Kerbals Name
-		#autoLOC_DF_00131 = Trait
-		#autoLOC_DF_00132 = The Kerbals Profession
-		#autoLOC_DF_00133 = Thaw
-		#autoLOC_DF_00134 = Thaw this kerbal on alarm activation
-		#autoLOC_DF_00135 = Freeze
-		#autoLOC_DF_00136 = Freeze this kerbal on alarm activation
-		#autoLOC_DF_00137 = Modify
-		#autoLOC_DF_00138 = Modify this Alarms settings
-		
-		#autoLOC_DF_00139 = Switch to Vessel
-		#autoLOC_DF_00140 = Not Now
-		#autoLOC_DF_00141 = Don't switch vessel now
-		#autoLOC_DF_00142 = Automatic Switch to vessel failed.\nPlease switch manually to vessel Immediately
-		#autoLOC_DF_00143 = Switch to DeepFreeze vessel required
-		
-		#autoLOC_DF_00144 = DeepFreeze Options
-		#autoLOC_DF_00145 = ElectricCharge Required to run Freezers
-		#autoLOC_DF_00146 = If on, EC is required to run freezers
-		#autoLOC_DF_00147 = Fatal EC/Heat Option
-		#autoLOC_DF_00148 = If on Kerbals will die if EC runs out or it gets too hot
-		#autoLOC_DF_00149 = Non Fatal Comatose Time(in secs)
-		#autoLOC_DF_00150 = The time in seconds a kerbal is comatose\n if fatal EC / Heat option is off
-		#autoLOC_DF_00151 = AutoRecover Frozen Kerbals at KSC
-		#autoLOC_DF_00152 = If on, will AutoRecover Frozen Kerbals at the KSC\n and deduct the Cost from your funds
-		#autoLOC_DF_00153 = Cost to Thaw a Kerbal at KSC
-		#autoLOC_DF_00154 = Amt of currency Reqd to Freeze a Kerbal from the KSC
-		#autoLOC_DF_00155 = EC Reqd to Freeze/Thaw a Kerbal
-		#autoLOC_DF_00156 = Amt of ElecCharge Reqd to Freeze/Thaw a Kerbal.
-		#autoLOC_DF_00157 = Glykerol Reqd to Freeze a Kerbal
-		#autoLOC_DF_00158 = Amt of Glykerol used to Freeze a Kerbal,\nOverrides Part values.
-		#autoLOC_DF_00159 = DeepFreeze Temperatures
-		#autoLOC_DF_00160 = Get your calculator out.
-		#autoLOC_DF_00161 = Temps are in (K)elvin. (K) = (C)elcius + 273.15. (K) = ((F)arenheit + 459.67) × 5/9. Get your calculator out
-		#autoLOC_DF_00162 = Regulated Temperatures Required
-		#autoLOC_DF_00163 = If on, Regulated Temps apply to freeze\nand keep Kerbals Frozen.
-		#autoLOC_DF_00164 = Min. Temp. for Freezer to Freeze(K)
-		#autoLOC_DF_00165 = The minimum temperature (in Kelvin) for a Freezer\nto be able to Freeze a Kerbal.
-		#autoLOC_DF_00166 = Max. Temp. to keep Kerbals Frozen(K)
-		#autoLOC_DF_00167 = The maximum temperature (in Kelvin) for a Freezer\nto keep Kerbals frozen.
-		#autoLOC_DF_00168 = Heat generated per kerbal (kW/min)
-		#autoLOC_DF_00169 = Amount of thermal heat (kW) generated\nby equipment for each frozen kerbal per minute.
-		#autoLOC_DF_00170 = Heat generated freezer process(kW)
-		#autoLOC_DF_00171 = Amount of thermal heat (kW) generated\nwith each thaw/freeze process.
-		#autoLOC_DF_00172 = Show Part Temperatures in Kelvin
-		#autoLOC_DF_00173 = If on Part right click will show temp in Kelvin,\nif Off will show in Celcius.
-		#autoLOC_DF_00174 = DeepFreeze Misc.
-		#autoLOC_DF_00175 = Freezer Strip Lights On
-		#autoLOC_DF_00176 = Turn off if you do not want the internal\nfreezer strip lights to function.
-		#autoLOC_DF_00177 = ToolTips On
-		#autoLOC_DF_00178 = Turn the Tooltips on and off.
-		#autoLOC_DF_00179 = Editor Filter
-		#autoLOC_DF_00180 = Turn the DeepFreeze Editor filter Category on and off.
-		#autoLOC_DF_00181 = Use Stock App Launcher Icon
-		#autoLOC_DF_00182 = If on, the Stock Application launcher will be used,\nif off will use Blizzy Toolbar if installed.
-		#autoLOC_DF_00183 = Extra Debug Logging
-		#autoLOC_DF_00184 = Turn this On to capture lots of extra information\ninto the KSP log for reporting a problem.
-		
-		#autoLOC_DF_00185 = CRY-0300 Cryonic Freezing Chamber
-		#autoLOC_DF_00186 = REPOSoftTech
-		#autoLOC_DF_00187 = Designed for long term storage of 1 kerbal. The CRY-0300 uses Glykerol and ElectricCharge to freeze or thaw one Kerbal. Please ensure you have enough ElectricCharge capacity on your ship. The CRY-0300 comes stocked with 10 units of Glykerol. CAUTION: The CRY-0300 also requires ElectricCharge per minute per Kerbal to keep it's Monitoring Systems Functioning. If it cannot get this ElectricCharge there is a risk of frozen Kerbals dying. 		
-		#autoLOC_DF_00188 = deepfreeze cryogenic freezer
-		#autoLOC_DF_00189 = CRY-0300R Cryonic Freezing Chamber
-		#autoLOC_DF_00190 = Designed for long term storage of 1 kerbal. The CRY-0300R uses Glykerol and ElectricCharge to freeze or thaw one Kerbal. Please ensure you have enough ElectricCharge capacity on your ship. The CRY-0300R comes stocked with 10 units of Glykerol. CAUTION: The CRY-0300R also requires ElectricCharge per minute per Kerbal to keep it's Monitoring Systems Functioning. If it cannot get this ElectricCharge there is a risk of frozen Kerbals dying.
-		#autoLOC_DF_00191 = CRY-1300 Cryonic Freezing Chamber
-		#autoLOC_DF_00192 = Designed for long term storage of up to 3 Kerbals. The CRY-1300 uses Glykerol and ElectricCharge to freeze or thaw one Kerbal. Please ensure you have enough ElectricCharge capacity on your ship. The CRY-1300 comes stocked with 15 units of Glykerol. CAUTION: The CRY-1300 also requires ElectricCharge per minute per Kerbal to keep it's Monitoring Systems Functioning. If it cannot get this ElectricCharge there is a risk of frozen Kerbals dying. 
-		#autoLOC_DF_00193 = CRY-2300 Cryonic Freezing Chamber
-		#autoLOC_DF_00194 = Designed for long term storage of up to 10 Kerbals. The CRY-2300 uses Glykerol and ElectricCharge to freeze or thaw one Kerbal. Please ensure you have enough ElectricCharge capacity on your ship. The CRY-2300 comes stocked with 50 units of Glykerol. CAUTION: The CRY-2300 also requires ElectricCharge per minute per Kerbal to keep it's Monitoring Systems Functioning. If it cannot get this ElectricCharge there is a risk of frozen Kerbals dying. 
-		#autoLOC_DF_00195 = RS-X20R Glykerol Container
-		#autoLOC_DF_00196 = The RS-X20R is a small-volume Radial Glykerol container, for all your Kerbal Freezing and Thawing needs. Brought to you by the good folks at REPOSoftTech. Warranty void if filled with Glykerol.
-		#autoLOC_DF_00197 = deepfreeze cryogenic freezer glykerol tank
-		
-		#autoLOC_DF_00198 = Experts in the field of cryogenics, ergonomics and electrical equipment, the kerbals at REPOSoftTech are trying hard to keep all space fairing kerbals alive and their missions successful.
-		
-		#autoLOC_DF_00199 = Freeze <<1>>
-		#autoLOC_DF_00200 = Thaw <<1>>
-		
-		#autoLOC_DF_00201 = Procesamiento de naves sin Carga
-		#autoLOC_DF_00202 = Si se habilita, CongelaciónProfunda procesará los recursos en las naves sin carga. Si está deshabilitado, no lo hará y jugará el juego de recuperación y estimación.
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.		
 	}
 }
 
@@ -867,6 +657,10 @@ Localization
 		
 		#autoLOC_DF_00201 = Unloaded Vessel Processing
 		#autoLOC_DF_00202 = If enabled DeepFreeze will process resources on unloaded vessels. If disabled, it won't and play the catchup and estimation game.		
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.		
 	}
 }
 
@@ -1085,6 +879,10 @@ Localization
 		
 		#autoLOC_DF_00201 = Обработка выгруженных КА
 		#autoLOC_DF_00202 = Если включено, анабиоз будет считать ресурсы выгруженных космических аппаратов. \n Если выключено, TAC LS не будет просчитывать ресурсы таких космических аппаратов в игре. \nВыгруженный космический аппарат не управляется непосредственно \nи находится очень далеко от активного КА,  поэтому, для экономии ресурсов, игра просчитывает для него \nТОЛЬКО орбитальную механику и некоторые другие параметры.		
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.		
 	}
 }
 
@@ -1302,7 +1100,11 @@ Localization
 		#autoLOC_DF_00200 = 唤醒 <<1>>
 		
 		#autoLOC_DF_00201 = 卸船处理
-		#autoLOC_DF_00202 = 如果启用了深度冻结，将处理卸载船只上的资源。如果禁用它，它就不会追赶和评估游戏。		
+		#autoLOC_DF_00202 = 如果启用了深度冻结，将处理卸载船只上的资源。如果禁用它，它就不会追赶和评估游戏。	
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.				
 	}
 }
 
@@ -1522,5 +1324,9 @@ Localization
 		
 		#autoLOC_DF_00201 = Unloaded Vessel Processing
 		#autoLOC_DF_00202 = If enabled DeepFreeze will process resources on unloaded vessels. If disabled, it won't and play the catchup and estimation game.		
+		#autoLOC_DF_00203 = Beep Sounds On
+		#autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.		
+		#autoLOC_DF_00205 = Other Sounds On
+		#autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.		
 	}
 }

--- a/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
+++ b/Distribution/GameData/REPOSoftTech/DeepFreeze/DeepFreezeContinued.version
@@ -2,8 +2,8 @@
 "NAME":"DeepFreeze Continued...",
 "URL":"http://ksp-avc.cybutek.net/version.php?id=183",
 "DOWNLOAD":"http://spacedock.info/mod/142/DeepFreeze%20Continued...",
-"VERSION":{"MAJOR":0,"MINOR":30,"PATCH":0,"BUILD":0},
-"KSP_VERSION":{"MAJOR":1,"MINOR":11,"PATCH":0},
-"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":11,"PATCH":0},
-"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":11,"PATCH":99}
+"VERSION":{"MAJOR":0,"MINOR":31,"PATCH":0,"BUILD":0},
+"KSP_VERSION":{"MAJOR":1,"MINOR":12,"PATCH":0},
+"KSP_VERSION_MIN":{"MAJOR":1,"MINOR":12,"PATCH":0},
+"KSP_VERSION_MAX":{"MAJOR":1,"MINOR":12,"PATCH":99}
 }

--- a/Source/DFIntMemory.cs
+++ b/Source/DFIntMemory.cs
@@ -876,8 +876,12 @@ namespace DF
                         while (enumerator.MoveNext())
                         {
                             if (enumerator.Current.id == vesselId)
+                            {
                                 vessel = enumerator.Current;
+                                break;
+                            }
                         }
+                        enumerator.Dispose();
                     }
                     else
                         continue;
@@ -904,7 +908,7 @@ namespace DF
                             }
                         }
                     }
-                     Utilities.Log("Exception: " + ex);
+                    Utilities.Log("Exception: " + ex);
                     if (entry.Value.numFrznCrew == 0)
                     {
                          Utilities.Log("Removing entry as vessel has no frozen crew");

--- a/Source/DFSettings.cs
+++ b/Source/DFSettings.cs
@@ -59,6 +59,8 @@ namespace DF
         internal float ECLowWarningTime ;
         internal float EClowCriticalTime ;
         internal bool StripLightsActive ;
+        internal bool BeepSoundsActive;
+        internal bool OtherSoundsActive;
         internal int internalFrzrCamCode ;
         internal int internalNxtFrzrCamCode ;
         internal int internalPrvFrzrCamCode ;
@@ -97,6 +99,8 @@ namespace DF
             ECLowWarningTime = 3600f;
             EClowCriticalTime = 900f;
             StripLightsActive = true;
+            BeepSoundsActive = true;
+            OtherSoundsActive = true;
             internalFrzrCamCode = 100;
             internalNxtFrzrCamCode = 110;
             internalPrvFrzrCamCode = 98;
@@ -226,6 +230,8 @@ namespace DF
                     heatamtMonitoringFrznKerbals = DF_SettingsParms_Sec2.heatamtMonitoringFrznKerbals;
                     TempinKelvin = DF_SettingsParms_Sec2.TempinKelvin;
                     StripLightsActive = DF_SettingsParms_Sec3.StripLightsActive;
+                    BeepSoundsActive = DF_SettingsParms_Sec3.BeepSoundsActive;
+                    OtherSoundsActive = DF_SettingsParms_Sec3.OtherSoundsActive;
                     if (EditorFilter != DF_SettingsParms_Sec3.EditorFilter)
                     {
                         EditorFilter = DF_SettingsParms_Sec3.EditorFilter;

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.30.0.0")]
-[assembly: AssemblyFileVersion("0.30.0.0")]
-[assembly: KSPAssembly("DeepFreeze", 0, 30)] 
+[assembly: AssemblyVersion("0.31.0.0")]
+[assembly: AssemblyFileVersion("0.31.0.0")]
+[assembly: KSPAssembly("DeepFreeze", 0, 31)] 

--- a/Source/SettingsParms.cs
+++ b/Source/SettingsParms.cs
@@ -211,6 +211,12 @@ namespace DF
         [GameParameters.CustomParameterUI("#autoLOC_DF_00175", autoPersistance = true, toolTip = "#autoLOC_DF_00176")] //#autoLOC_DF_00175 = Freezer Strip Lights On #autoLOC_DF_00176 = Turn off if you do not want the internal\nfreezer strip lights to function.
         public bool StripLightsActive = true;
 
+        [GameParameters.CustomParameterUI("#autoLOC_DF_00203", autoPersistance = true, toolTip = "#autoLOC_DF_00204")] //#autoLOC_DF_00203 = Beep Sounds On. #autoLOC_DF_00204 = If enabled Beep sounds are heard inside freezer parts with frozen kerbals.	
+        public bool BeepSoundsActive = true;
+
+        [GameParameters.CustomParameterUI("#autoLOC_DF_00205", autoPersistance = true, toolTip = "#autoLOC_DF_00206")] //#autoLOC_DF_00205 = Other Sounds On. #autoLOC_DF_00206 = If enabled all other DeepFreeze sounds are heard.	
+        public bool OtherSoundsActive = true;
+
         [GameParameters.CustomParameterUI("#autoLOC_DF_00177", autoPersistance = true, toolTip = "#autoLOC_DF_00178")] //#autoLOC_DF_00177 = ToolTips On #autoLOC_DF_00178 = Turn the Tooltips on and off.
         public bool ToolTips = true;
 


### PR DESCRIPTION
﻿V0.31.0.0
Re-Compile for KSP 1.12.x
Added difficulty settings to turn off internal beep sounds and all sounds.
Fix background resources - Kopernicus solar panels integration.
Fix Portraits showing from kerbals in loaded vessels that aren't the active vessel.
Fix timing issue with the Cryopod door animation and freeze glass animation playing at the same time. They now play one after another as they used to/should.